### PR TITLE
Fix component initialization and teardown

### DIFF
--- a/lib/kmdc-drawer/src/jsMain/kotlin/MDCDrawer.kt
+++ b/lib/kmdc-drawer/src/jsMain/kotlin/MDCDrawer.kt
@@ -25,6 +25,7 @@ private external object MDCDrawerModule {
     companion object {
       fun attachTo(element: Element): MDCDrawer
     }
+    fun destroy()
 
     var open: Boolean
   }
@@ -65,12 +66,15 @@ public fun MDCDrawer(
   Aside(
     attrs = {
       classes("mdc-drawer", *options.type.classes, *options.state.classes)
+      ref {
+        it.mdc = MDCDrawerModule.MDCDrawer.attachTo(it)
+        onDispose {
+          it.mdc<MDCDrawerModule.MDCDrawer> { destroy() }
+        }
+      }
       attrs?.invoke(this)
     },
   ) {
-    DomSideEffect(null) {
-      it.mdc = MDCDrawerModule.MDCDrawer.attachTo(element = it)
-    }
     DomSideEffect(options.isOpen) {
       it.mdc<MDCDrawerModule.MDCDrawer> { open = options.isOpen }
     }

--- a/lib/kmdc-form-field/src/jsMain/kotlin/MDCFormField.kt
+++ b/lib/kmdc-form-field/src/jsMain/kotlin/MDCFormField.kt
@@ -1,6 +1,7 @@
 package dev.petuska.kmdc.form.field
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffectScope
 import dev.petuska.kmdc.core.Builder
 import dev.petuska.kmdc.core.ComposableBuilder
 import dev.petuska.kmdc.core.MDCDsl
@@ -8,7 +9,6 @@ import dev.petuska.kmdc.core.mdc
 import dev.petuska.kmdc.ripple.MDCRippleModule
 import org.jetbrains.compose.web.attributes.AttrsBuilder
 import org.jetbrains.compose.web.dom.Div
-import org.jetbrains.compose.web.dom.DomEffectScope
 import org.jetbrains.compose.web.dom.ElementScope
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLDivElement
@@ -21,7 +21,7 @@ public external val MDCFormFieldStyle: dynamic
 public external object MDCFormFieldModule {
   public class MDCFormField(element: Element) {
     public companion object {
-      public fun attachTo(element: Element)
+      public fun attachTo(element: Element): MDCFormField
     }
 
     public var input: MDCFormFieldInput
@@ -42,7 +42,7 @@ public data class MDCFormFieldOpts(
 }
 
 public class MDCFormFieldScope(scope: ElementScope<HTMLElement>) : ElementScope<HTMLElement> by scope {
-  public fun DomEffectScope.setInput(htmlInput: Element, mdcInput: MDCFormFieldModule.MDCFormFieldInput) {
+  public fun DisposableEffectScope.setInput(htmlInput: Element, mdcInput: MDCFormFieldModule.MDCFormFieldInput) {
     htmlInput.parentElement?.let {
       if (it.classList.contains("mdc-form-field")) {
         it.mdc<MDCFormFieldModule.MDCFormField> { input = mdcInput }
@@ -69,11 +69,12 @@ public fun MDCFormField(
   Div(attrs = {
     classes("mdc-form-field", *options.align.classes)
     if (options.nowrap) classes("mdc-form-field--nowrap")
+    ref {
+      it.mdc = MDCFormFieldModule.MDCFormField.attachTo(it)
+      onDispose {}
+    }
     attrs?.invoke(this)
   }) {
-    DomSideEffect {
-      it.mdc = MDCFormFieldModule.MDCFormField.attachTo(it)
-    }
     content?.let { MDCFormFieldScope(this).it() }
   }
 }

--- a/lib/kmdc-icon-button/src/jsMain/kotlin/MDCIconButton.kt
+++ b/lib/kmdc-icon-button/src/jsMain/kotlin/MDCIconButton.kt
@@ -22,8 +22,9 @@ private external val MDCIconButtonStyle: dynamic
 private external object MDCIconButtonModule {
   class MDCIconButtonToggle(element: Element) {
     companion object {
-      fun attachTo(element: Element)
+      fun attachTo(element: Element): MDCIconButtonToggle
     }
+    fun destroy()
   }
 }
 
@@ -48,12 +49,15 @@ public fun MDCIconButton(
   Button(
     attrs = {
       classes(*listOfNotNull("mdc-icon-button", if (options.on) "mdc-icon-button--on" else null).toTypedArray())
+      ref {
+        it.mdc = MDCIconButtonModule.MDCIconButtonToggle.attachTo(it)
+        onDispose {
+          it.mdc<MDCIconButtonModule.MDCIconButtonToggle> { destroy() }
+        }
+      }
       attrs?.invoke(this)
     },
   ) {
-    DomSideEffect {
-      it.mdc = MDCIconButtonModule.MDCIconButtonToggle.attachTo(it)
-    }
     MDCRipple()
     Span(attrs = { classes("mdc-icon-button__ripple") })
     content?.let { MDCIconButtonScope(this).it() }
@@ -75,12 +79,15 @@ public fun MDCIconLink(
   A(
     attrs = {
       classes(*listOfNotNull("mdc-icon-button", if (options.on) "mdc-icon-button--on" else null).toTypedArray())
+      ref {
+        it.mdc = MDCIconButtonModule.MDCIconButtonToggle.attachTo(it)
+        onDispose {
+          it.mdc<MDCIconButtonModule.MDCIconButtonToggle> { destroy() }
+        }
+      }
       attrs?.invoke(this)
     },
   ) {
-    DomSideEffect {
-      it.mdc = MDCIconButtonModule.MDCIconButtonToggle.attachTo(it)
-    }
     MDCRipple()
     Span(attrs = { classes("mdc-icon-button__ripple") })
     content?.let { MDCIconLinkScope(this).it() }

--- a/lib/kmdc-linear-progress/src/jsMain/kotlin/MDCLinearProgress.kt
+++ b/lib/kmdc-linear-progress/src/jsMain/kotlin/MDCLinearProgress.kt
@@ -61,11 +61,12 @@ public fun MDCLinearProgress(
     attr("aria-valuemax", "1")
     attr("aria-valuenow", "0")
     options.label?.let { attr("aria-label", it) }
+    ref {
+      it.mdc = MDCLinearProgressModule.MDCLinearProgress.attachTo(it)
+      onDispose {}
+    }
     attrs?.invoke(this)
   }) {
-    DomSideEffect {
-      it.mdc = MDCLinearProgressModule.MDCLinearProgress.attachTo(it)
-    }
     DomSideEffect(options.indeterminate) {
       it.mdc<MDCLinearProgressModule.MDCLinearProgress> { determinate = !options.indeterminate }
     }

--- a/lib/kmdc-list/src/jsMain/kotlin/MDCList.kt
+++ b/lib/kmdc-list/src/jsMain/kotlin/MDCList.kt
@@ -31,6 +31,7 @@ public external object MDCListModule {
     public companion object {
       public fun attachTo(element: Element): MDCList
     }
+    public fun destroy()
 
     public var vertical: Boolean
     public val listElements: Array<Element>
@@ -90,13 +91,16 @@ public fun MDCList(
   Ul(attrs = {
     classes("mdc-deprecated-list", *options.size.classes, *options.type.classes)
     if (options.singleSelection) attr("role", "listbox")
-    attrs?.invoke(this)
-  }) {
-    DomSideEffect {
+    ref {
       val mdc = MDCListModule.MDCList.attachTo(it)
       mdc.singleSelection = options.singleSelection
       it.mdc = mdc
+      onDispose {
+        it.mdc<MDCListModule.MDCList> { destroy() }
+      }
     }
+    attrs?.invoke(this)
+  }) {
     DomSideEffect(options.singleSelection) {
       it.mdc<MDCListModule.MDCList> { singleSelection = options.singleSelection }
     }
@@ -120,13 +124,16 @@ public fun MDCNavList(
   Nav(attrs = {
     classes("mdc-deprecated-list", *options.size.classes, *options.type.classes)
     if (options.singleSelection) attr("role", "listbox")
-    attrs?.invoke(this)
-  }) {
-    DomSideEffect {
+    ref {
       val mdc = MDCListModule.MDCList.attachTo(it)
       mdc.singleSelection = options.singleSelection
       it.mdc = mdc
+      onDispose {
+        it.mdc<MDCListModule.MDCList> { destroy() }
+      }
     }
+    attrs?.invoke(this)
+  }) {
     DomSideEffect(options.singleSelection) {
       it.mdc<MDCListModule.MDCList> { singleSelection = options.singleSelection }
     }

--- a/lib/kmdc-ripple/src/jsMain/kotlin/MDCRipple.kt
+++ b/lib/kmdc-ripple/src/jsMain/kotlin/MDCRipple.kt
@@ -15,7 +15,7 @@ public external object MDCRippleModule {
 
   public class MDCRipple(element: Element, opts: MDCRippleAttachOpts = definedExternally) {
     public companion object {
-      public fun attachTo(element: Element, opts: MDCRippleAttachOpts = definedExternally)
+      public fun attachTo(element: Element, opts: MDCRippleAttachOpts = definedExternally): MDCRipple
     }
   }
 }
@@ -31,12 +31,13 @@ public fun ElementScope<*>.MDCRipple(
   opts: Builder<MDCRippleOpts>? = null
 ) {
   val options = MDCRippleOpts().apply { opts?.invoke(this) }
-  DomSideEffect {
+  DisposableRefEffect {
     MDCRippleModule.MDCRipple.attachTo(
       element = it,
       opts = jsObject {
         isUnbounded = options.isUnbounded
       }
     )
+    onDispose {}
   }
 }

--- a/lib/kmdc-textfield/src/jsMain/kotlin/MDCTextArea.kt
+++ b/lib/kmdc-textfield/src/jsMain/kotlin/MDCTextArea.kt
@@ -45,11 +45,14 @@ public fun MDCTextArea(
       classes("mdc-text-field", "mdc-text-field--textarea", *options.type.classes)
       if (options.label == null) classes("mdc-text-field--no-label")
       if (options.disabled) classes("mdc-text-field--disabled")
+      ref {
+        it.mdc = MDCTextFieldModule.MDCTextField.attachTo(it)
+        onDispose {
+          it.mdc<MDCTextFieldModule.MDCTextField> { destroy() }
+        }
+      }
     }
   ) {
-    DomSideEffect {
-      it.mdc = MDCTextFieldModule.MDCTextField.attachTo(it)
-    }
     options.maxLength?.let {
       Div(attrs = {
         classes("mdc-text-field-character-counter")

--- a/lib/kmdc-textfield/src/jsMain/kotlin/MDCTextField.kt
+++ b/lib/kmdc-textfield/src/jsMain/kotlin/MDCTextField.kt
@@ -27,8 +27,9 @@ public external val MDCTextFieldStyle: dynamic
 public external object MDCTextFieldModule {
   public class MDCTextField(element: Element) {
     public companion object {
-      public fun attachTo(element: Element)
+      public fun attachTo(element: Element): MDCTextField
     }
+    public fun destroy()
 
     public var value: String
     public var disabled: Boolean
@@ -100,11 +101,14 @@ public fun MDCTextField(
       classes("mdc-text-field", *options.type.classes)
       if (options.label == null) classes("mdc-text-field--no-label")
       if (options.disabled) classes("mdc-text-field--disabled")
+      ref {
+        it.mdc = MDCTextFieldModule.MDCTextField.attachTo(it)
+        onDispose {
+          it.mdc<MDCTextFieldModule.MDCTextField> { destroy() }
+        }
+      }
     }
   ) {
-    DomSideEffect {
-      it.mdc = MDCTextFieldModule.MDCTextField.attachTo(it)
-    }
     when (options.type) {
       MDCTextFieldCommonOpts.Type.Filled -> {
         Span(attrs = { classes("mdc-text-field__ripple") })

--- a/lib/kmdc-top-app-bar/src/jsMain/kotlin/MDCTopAppBar.kt
+++ b/lib/kmdc-top-app-bar/src/jsMain/kotlin/MDCTopAppBar.kt
@@ -25,6 +25,7 @@ private external object MDCTopAppBarModule {
     companion object {
       fun attachTo(element: Element): MDCTopAppBar
     }
+    fun destroy()
   }
 }
 
@@ -80,12 +81,15 @@ public fun MDCTopAppBarContextScope.MDCTopAppBar(
   Header(
     attrs = {
       classes("mdc-top-app-bar", *type.classes)
+      ref {
+        it.mdc = MDCTopAppBarModule.MDCTopAppBar.attachTo(it)
+        onDispose {
+          it.mdc<MDCTopAppBarModule.MDCTopAppBar> { destroy() }
+        }
+      }
       attrs?.invoke(this)
     },
   ) {
-    DomSideEffect {
-      it.mdc = MDCTopAppBarModule.MDCTopAppBar.attachTo(it)
-    }
     content?.let { MDCTopAppBarScope(this).it() }
   }
 }


### PR DESCRIPTION
This PR intends to fix component lifecycle handling, as seems to be required according to the [MDC guide](https://material.io/develop/web/guides/framework-integration):
* Use `ref` or `DisposableRefEffect` for component initialization (which runs once on entering a composition) instead of `DomSideEffect` (which runs on each recomposition).
* Add component teardown via `destroy()`, which was previously missing.