### PR TITLE
Fix text field notch and floating label, switch to controlled mode

### DIFF
--- a/lib/kmdc-checkbox/src/jsMain/kotlin/MDCCheckbox.kt
+++ b/lib/kmdc-checkbox/src/jsMain/kotlin/MDCCheckbox.kt
@@ -3,7 +3,11 @@ package dev.petuska.kmdc.checkbox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffectScope
 import androidx.compose.runtime.remember
-import dev.petuska.kmdc.core.*
+import dev.petuska.kmdc.core.Builder
+import dev.petuska.kmdc.core.MDCDsl
+import dev.petuska.kmdc.core.Path
+import dev.petuska.kmdc.core.Svg
+import dev.petuska.kmdc.core.mdc
 import dev.petuska.kmdc.form.field.MDCFormFieldModule
 import dev.petuska.kmdc.form.field.MDCFormFieldScope
 import dev.petuska.kmdc.ripple.MDCRippleModule
@@ -27,6 +31,7 @@ public external object MDCCheckboxModule {
     public companion object {
       public fun attachTo(element: Element): MDCCheckbox
     }
+
     public fun destroy()
 
     public var checked: Boolean
@@ -49,10 +54,11 @@ public data class MDCCheckboxOpts(
 @MDCDsl
 @Composable
 public fun MDCCheckbox(
+  checked: Boolean,
   opts: Builder<MDCCheckboxOpts>? = null,
   attrs: (InputAttrsBuilder<Boolean>.() -> Unit)? = null,
 ) {
-  MDCCheckboxBody(opts, attrs)
+  MDCCheckboxBody(checked, opts, attrs)
 }
 
 /**
@@ -61,10 +67,11 @@ public fun MDCCheckbox(
 @MDCDsl
 @Composable
 public fun MDCFormFieldScope.MDCCheckbox(
+  checked: Boolean,
   opts: Builder<MDCCheckboxOpts>? = null,
   attrs: (InputAttrsBuilder<Boolean>.() -> Unit)? = null,
 ) {
-  MDCCheckboxBody(opts, attrs) { parent, mdcCheckbox ->
+  MDCCheckboxBody(checked, opts, attrs) { parent, mdcCheckbox ->
     setInput(parent, mdcCheckbox)
   }
 }
@@ -72,6 +79,7 @@ public fun MDCFormFieldScope.MDCCheckbox(
 @MDCDsl
 @Composable
 private fun MDCCheckboxBody(
+  checked: Boolean,
   opts: Builder<MDCCheckboxOpts>? = null,
   attrs: (InputAttrsBuilder<Boolean>.() -> Unit)? = null,
   initialize: (DisposableEffectScope.(parent: HTMLDivElement, mdcCheckbox: MDCCheckboxModule.MDCCheckbox) -> Unit)? = null,
@@ -96,8 +104,11 @@ private fun MDCCheckboxBody(
     DomSideEffect(options.indeterminate) {
       it.mdc<MDCCheckboxModule.MDCCheckbox> { indeterminate = options.indeterminate }
     }
+    // WORKAROUND https://github.com/JetBrains/compose-jb/issues/1528
+    //     We cannot use the controlled CheckboxInput directly, but the workaround is functionally equivalent.
     Input(type = InputType.Checkbox, attrs = {
-      classes("mdc-checkbox__native-control")
+      classes("mdc-checkbox__native-control")  // This must precede `checked()`
+      checked(checked)  // This must follow `classes(...)`
       id(checkboxId)
       if (options.disabled) disabled()
       if (options.indeterminate) attr("data-indeterminate", "true")

--- a/lib/kmdc-textfield/src/jsMain/kotlin/MDCTextArea.kt
+++ b/lib/kmdc-textfield/src/jsMain/kotlin/MDCTextArea.kt
@@ -9,11 +9,7 @@ import org.jetbrains.compose.web.attributes.builders.TextAreaAttrsBuilder
 import org.jetbrains.compose.web.attributes.cols
 import org.jetbrains.compose.web.attributes.maxLength
 import org.jetbrains.compose.web.attributes.rows
-import org.jetbrains.compose.web.dom.Div
-import org.jetbrains.compose.web.dom.Label
-import org.jetbrains.compose.web.dom.Span
-import org.jetbrains.compose.web.dom.Text
-import org.jetbrains.compose.web.dom.TextArea
+import org.jetbrains.compose.web.dom.*
 import kotlin.random.Random
 
 public class MDCTextAreaOpts(
@@ -32,6 +28,7 @@ public class MDCTextAreaOpts(
 @MDCDsl
 @Composable
 public fun MDCTextArea(
+  value: String,
   opts: Builder<MDCTextAreaOpts>? = null,
   attrs: (TextAreaAttrsBuilder.() -> Unit)? = null,
 ) {
@@ -62,20 +59,22 @@ public fun MDCTextArea(
       MDCTextFieldCommonOpts.Type.Filled -> {
         Span(attrs = { classes("mdc-text-field__ripple") })
         Span(attrs = { classes("mdc-text-field__resizer") }) {
-          MDCTextAreaInput(options, attrs, labelId, helperId)
+          MDCTextAreaInput(value, options, attrs, labelId, helperId)
         }
         options.label?.let {
           Span(attrs = {
             classes("mdc-floating-label")
+            if (value.isNotEmpty())
+              classes("mdc-floating-label--float-above")
             id("mdc-floating-label__$labelId")
           }) { Text(it) }
         }
         Span(attrs = { classes("mdc-line-ripple") })
       }
       MDCTextFieldCommonOpts.Type.Outlined -> {
-        MDCTextFieldNotch(options, labelId)
+        MDCTextFieldNotch(options, labelId, value.isNotEmpty())
         Span(attrs = { classes("mdc-text-field__resizer") }) {
-          MDCTextAreaInput(options, attrs, labelId, helperId)
+          MDCTextAreaInput(value, options, attrs, labelId, helperId)
         }
       }
     }
@@ -85,12 +84,13 @@ public fun MDCTextArea(
 
 @Composable
 private fun MDCTextAreaInput(
+  value: String,
   options: MDCTextAreaOpts,
   attrs: (TextAreaAttrsBuilder.() -> Unit)?,
   labelId: String,
   helperId: String,
 ) {
-  TextArea(attrs = {
+  TextArea(value, attrs = {
     classes("mdc-text-field__input")
     rows(options.rows.toInt())
     cols(options.columns.toInt())

--- a/lib/kmdc-textfield/src/jsMain/kotlin/MDCTextArea.kt
+++ b/lib/kmdc-textfield/src/jsMain/kotlin/MDCTextArea.kt
@@ -9,7 +9,11 @@ import org.jetbrains.compose.web.attributes.builders.TextAreaAttrsBuilder
 import org.jetbrains.compose.web.attributes.cols
 import org.jetbrains.compose.web.attributes.maxLength
 import org.jetbrains.compose.web.attributes.rows
-import org.jetbrains.compose.web.dom.*
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.Label
+import org.jetbrains.compose.web.dom.Span
+import org.jetbrains.compose.web.dom.Text
+import org.jetbrains.compose.web.dom.TextArea
 import kotlin.random.Random
 
 public class MDCTextAreaOpts(

--- a/lib/kmdc-textfield/src/jsMain/kotlin/MDCTextField.kt
+++ b/lib/kmdc-textfield/src/jsMain/kotlin/MDCTextField.kt
@@ -1,21 +1,14 @@
 package dev.petuska.kmdc.textfield
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import dev.petuska.kmdc.core.Builder
 import dev.petuska.kmdc.core.MDCDsl
 import dev.petuska.kmdc.core.mdc
 import dev.petuska.kmdc.ripple.MDCRippleModule
-import org.jetbrains.compose.web.attributes.InputType
 import org.jetbrains.compose.web.attributes.builders.InputAttrsBuilder
 import org.jetbrains.compose.web.attributes.disabled
 import org.jetbrains.compose.web.attributes.maxLength
-import org.jetbrains.compose.web.dom.ContentBuilder
-import org.jetbrains.compose.web.dom.Div
-import org.jetbrains.compose.web.dom.Input
-import org.jetbrains.compose.web.dom.Label
-import org.jetbrains.compose.web.dom.Span
-import org.jetbrains.compose.web.dom.Text
+import org.jetbrains.compose.web.dom.*
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLDivElement
 import kotlin.random.Random
@@ -29,6 +22,7 @@ public external object MDCTextFieldModule {
     public companion object {
       public fun attachTo(element: Element): MDCTextField
     }
+
     public fun destroy()
 
     public var value: String
@@ -88,6 +82,7 @@ public class MDCTextFieldOpts(
 @MDCDsl
 @Composable
 public fun MDCTextField(
+  value: String,
   opts: Builder<MDCTextFieldOpts>? = null,
   attrs: (InputAttrsBuilder<String>.() -> Unit)? = null,
 ) {
@@ -115,6 +110,8 @@ public fun MDCTextField(
         options.label?.let {
           Span(attrs = {
             classes("mdc-floating-label")
+            if (value.isNotEmpty())
+              classes("mdc-floating-label--float-above")
             id("mdc-floating-label__$labelId")
           }) { Text(it) }
         }
@@ -132,12 +129,12 @@ public fun MDCTextField(
             Text(it)
           }
         }
-        MDCTextFieldInput(options, attrs, labelId, helperId)
+        MDCTextFieldInput(value, options, attrs, labelId, helperId)
         Span(attrs = { classes("mdc-line-ripple") })
       }
       MDCTextFieldCommonOpts.Type.Outlined -> {
-        MDCTextFieldNotch(options, labelId)
-        MDCTextFieldInput(options, attrs, labelId, helperId)
+        MDCTextFieldNotch(options, labelId, value.isNotEmpty())
+        MDCTextFieldInput(value, options, attrs, labelId, helperId)
       }
     }
   }
@@ -152,13 +149,21 @@ public fun MDCTextField(
 
 @MDCDsl
 @Composable
-internal fun MDCTextFieldNotch(options: MDCTextFieldCommonOpts, labelId: String) {
-  Span(attrs = { classes("mdc-notched-outline") }) {
+internal fun MDCTextFieldNotch(options: MDCTextFieldCommonOpts, labelId: String, inputIsNotEmpty: Boolean) {
+  Span(
+    attrs = {
+      classes("mdc-notched-outline")
+      if (inputIsNotEmpty)
+        classes("mdc-notched-outline--notched")
+    }
+  ) {
     Span(attrs = { classes("mdc-notched-outline__leading") })
     Span(attrs = { classes("mdc-notched-outline__notch") }) {
       options.label?.let {
         Span(attrs = {
           classes("mdc-floating-label")
+          if (inputIsNotEmpty)
+            classes("mdc-floating-label--float-above")
           id("mdc-floating-label__$labelId")
         }) { Text(it) }
       }
@@ -193,12 +198,13 @@ internal fun MDCTextFieldHelperLine(
 @MDCDsl
 @Composable
 private fun MDCTextFieldInput(
+  value: String,
   options: MDCTextFieldOpts,
   attrs: (InputAttrsBuilder<String>.() -> Unit)?,
   labelId: String,
   helperId: String,
 ) {
-  Input(InputType.Text, attrs = {
+  TextInput(value, attrs = {
     classes("mdc-text-field__input")
     attr("aria-labelledby", labelId)
     options.helperText?.let {

--- a/lib/kmdc-textfield/src/jsMain/kotlin/MDCTextField.kt
+++ b/lib/kmdc-textfield/src/jsMain/kotlin/MDCTextField.kt
@@ -1,6 +1,7 @@
 package dev.petuska.kmdc.textfield
 
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import dev.petuska.kmdc.core.Builder
 import dev.petuska.kmdc.core.MDCDsl
 import dev.petuska.kmdc.core.mdc
@@ -8,7 +9,12 @@ import dev.petuska.kmdc.ripple.MDCRippleModule
 import org.jetbrains.compose.web.attributes.builders.InputAttrsBuilder
 import org.jetbrains.compose.web.attributes.disabled
 import org.jetbrains.compose.web.attributes.maxLength
-import org.jetbrains.compose.web.dom.*
+import org.jetbrains.compose.web.dom.ContentBuilder
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.Label
+import org.jetbrains.compose.web.dom.Span
+import org.jetbrains.compose.web.dom.Text
+import org.jetbrains.compose.web.dom.TextInput
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLDivElement
 import kotlin.random.Random

--- a/sandbox/src/jsMain/kotlin/MultipleFieldsSample.kt
+++ b/sandbox/src/jsMain/kotlin/MultipleFieldsSample.kt
@@ -1,0 +1,115 @@
+package local.sandbox
+
+import androidx.compose.runtime.*
+import dev.petuska.kmdc.checkbox.MDCCheckbox
+import dev.petuska.kmdc.form.field.MDCFormField
+import dev.petuska.kmdc.layout.grid.MDCLayoutGridCells
+import dev.petuska.kmdc.layout.grid.MDCLayoutGridScope
+import dev.petuska.kmdc.textfield.MDCTextArea
+import dev.petuska.kmdc.textfield.MDCTextField
+import dev.petuska.kmdc.textfield.MDCTextFieldCommonOpts
+import org.jetbrains.compose.web.css.paddingBottom
+import org.jetbrains.compose.web.css.paddingTop
+import org.jetbrains.compose.web.css.px
+import org.jetbrains.compose.web.dom.Div
+
+/**
+ * Sample containing a user-selectable number of fields, placed inside an MDC grid.
+ */
+@Composable
+fun MDCLayoutGridScope.MultipleFieldsSample() {
+  var fieldCountText by remember { mutableStateOf("") }
+  MDCLayoutGridCells(
+    attrs = {
+      style { paddingBottom(24.px) }
+    }
+  ) {
+    MDCTextField(
+      fieldCountText,
+      opts = { label = "Field count" },
+      attrs = {
+        onInput { fieldCountText = it.value }
+      }
+    )
+  }
+
+  MDCLayoutGridCells {
+    val fieldCount = fieldCountText.toIntOrNull() ?: 0
+    var fieldContent by remember { mutableStateOf("") }
+    for (fieldNumber in 1..fieldCount) {
+      Div(attrs = { classes("mdc-layout-grid__cell--span-2") }) {
+        MDCTextField(
+          fieldContent,
+          opts = {
+            type =
+              if (fieldNumber.rem(2) == 1) MDCTextFieldCommonOpts.Type.Filled else MDCTextFieldCommonOpts.Type.Outlined
+            label = "TextField #$fieldNumber"
+          },
+          attrs = {
+            onInput { fieldContent = it.value }
+          }
+        )
+      }
+    }
+  }
+
+  MDCLayoutGridCells {
+    val fieldCount = fieldCountText.toIntOrNull() ?: 0
+    var fieldContent by remember { mutableStateOf("") }
+    for (fieldNumber in 1..fieldCount) {
+      Div(
+        attrs = {
+          classes("mdc-layout-grid__cell--span-2")
+          style {
+            paddingTop(12.px)
+            paddingBottom(12.px)
+          }
+        }
+      ) {
+        MDCTextArea(
+          fieldContent,
+          opts = {
+            type =
+              if (fieldNumber.rem(2) == 1) MDCTextFieldCommonOpts.Type.Filled else MDCTextFieldCommonOpts.Type.Outlined
+            label = "TextArea #$fieldNumber"
+          },
+          attrs = {
+            onInput { fieldContent = it.value }
+          }
+        )
+      }
+    }
+  }
+
+  var indeterminateEnabled by remember { mutableStateOf(false) }
+  MDCLayoutGridCells {
+    MDCFormField(attrs = { classes("mdc-layout-grid__cell--span-2") }) {
+      MDCCheckbox(
+        opts = { label = "Make indeterminate" },
+        attrs = {
+          checked(indeterminateEnabled)
+          onInput { indeterminateEnabled = it.value }
+        }
+      )
+    }
+  }
+
+  MDCLayoutGridCells {
+    val fieldCount = fieldCountText.toIntOrNull() ?: 0
+    var fieldContent by remember { mutableStateOf(false) }
+    for (fieldNumber in 1..fieldCount) {
+      MDCFormField(attrs = { classes("mdc-layout-grid__cell--span-2") }) {
+        MDCCheckbox(
+          opts = {
+            label = "Checkbox #$fieldNumber"
+            indeterminate = indeterminateEnabled
+          },
+          attrs = {
+            checked(fieldContent)
+            onInput { fieldContent = it.value }
+          }
+        )
+      }
+    }
+  }
+}

--- a/sandbox/src/jsMain/kotlin/MultipleFieldsSample.kt
+++ b/sandbox/src/jsMain/kotlin/MultipleFieldsSample.kt
@@ -92,9 +92,9 @@ fun MDCLayoutGridScope.MultipleFieldsSample() {
     MDCLayoutGridCell {
       MDCFormField(attrs = { classes("mdc-layout-grid__cell--span-2") }) {
         MDCCheckbox(
+          checked = indeterminateEnabled,
           opts = { label = "Make indeterminate" },
           attrs = {
-            checked(indeterminateEnabled)
             onInput { indeterminateEnabled = it.value }
           }
         )
@@ -109,12 +109,12 @@ fun MDCLayoutGridScope.MultipleFieldsSample() {
       MDCLayoutGridCell(opts = { span = 2u }) {
         MDCFormField {
           MDCCheckbox(
+            checked = fieldContent,
             opts = {
               label = "Checkbox #$fieldNumber"
               indeterminate = indeterminateEnabled
             },
             attrs = {
-              checked(fieldContent)
               onInput { fieldContent = it.value }
             }
           )

--- a/sandbox/src/jsMain/kotlin/MultipleFieldsSample.kt
+++ b/sandbox/src/jsMain/kotlin/MultipleFieldsSample.kt
@@ -1,8 +1,13 @@
 package local.sandbox
 
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import dev.petuska.kmdc.checkbox.MDCCheckbox
 import dev.petuska.kmdc.form.field.MDCFormField
+import dev.petuska.kmdc.layout.grid.MDCLayoutGridCell
 import dev.petuska.kmdc.layout.grid.MDCLayoutGridCells
 import dev.petuska.kmdc.layout.grid.MDCLayoutGridScope
 import dev.petuska.kmdc.textfield.MDCTextArea
@@ -11,7 +16,6 @@ import dev.petuska.kmdc.textfield.MDCTextFieldCommonOpts
 import org.jetbrains.compose.web.css.paddingBottom
 import org.jetbrains.compose.web.css.paddingTop
 import org.jetbrains.compose.web.css.px
-import org.jetbrains.compose.web.dom.Div
 
 /**
  * Sample containing a user-selectable number of fields, placed inside an MDC grid.
@@ -24,20 +28,22 @@ fun MDCLayoutGridScope.MultipleFieldsSample() {
       style { paddingBottom(24.px) }
     }
   ) {
-    MDCTextField(
-      fieldCountText,
-      opts = { label = "Field count" },
-      attrs = {
-        onInput { fieldCountText = it.value }
-      }
-    )
+    MDCLayoutGridCell {
+      MDCTextField(
+        fieldCountText,
+        opts = { label = "Field count" },
+        attrs = {
+          onInput { fieldCountText = it.value }
+        }
+      )
+    }
   }
 
   MDCLayoutGridCells {
     val fieldCount = fieldCountText.toIntOrNull() ?: 0
     var fieldContent by remember { mutableStateOf("") }
     for (fieldNumber in 1..fieldCount) {
-      Div(attrs = { classes("mdc-layout-grid__cell--span-2") }) {
+      MDCLayoutGridCell(opts = { span = 2u } ) {
         MDCTextField(
           fieldContent,
           opts = {
@@ -57,9 +63,9 @@ fun MDCLayoutGridScope.MultipleFieldsSample() {
     val fieldCount = fieldCountText.toIntOrNull() ?: 0
     var fieldContent by remember { mutableStateOf("") }
     for (fieldNumber in 1..fieldCount) {
-      Div(
+      MDCLayoutGridCell(
+        opts = { span = 2u },
         attrs = {
-          classes("mdc-layout-grid__cell--span-2")
           style {
             paddingTop(12.px)
             paddingBottom(12.px)
@@ -83,14 +89,16 @@ fun MDCLayoutGridScope.MultipleFieldsSample() {
 
   var indeterminateEnabled by remember { mutableStateOf(false) }
   MDCLayoutGridCells {
-    MDCFormField(attrs = { classes("mdc-layout-grid__cell--span-2") }) {
-      MDCCheckbox(
-        opts = { label = "Make indeterminate" },
-        attrs = {
-          checked(indeterminateEnabled)
-          onInput { indeterminateEnabled = it.value }
-        }
-      )
+    MDCLayoutGridCell {
+      MDCFormField(attrs = { classes("mdc-layout-grid__cell--span-2") }) {
+        MDCCheckbox(
+          opts = { label = "Make indeterminate" },
+          attrs = {
+            checked(indeterminateEnabled)
+            onInput { indeterminateEnabled = it.value }
+          }
+        )
+      }
     }
   }
 
@@ -98,17 +106,19 @@ fun MDCLayoutGridScope.MultipleFieldsSample() {
     val fieldCount = fieldCountText.toIntOrNull() ?: 0
     var fieldContent by remember { mutableStateOf(false) }
     for (fieldNumber in 1..fieldCount) {
-      MDCFormField(attrs = { classes("mdc-layout-grid__cell--span-2") }) {
-        MDCCheckbox(
-          opts = {
-            label = "Checkbox #$fieldNumber"
-            indeterminate = indeterminateEnabled
-          },
-          attrs = {
-            checked(fieldContent)
-            onInput { fieldContent = it.value }
-          }
-        )
+      MDCLayoutGridCell(opts = { span = 2u }) {
+        MDCFormField {
+          MDCCheckbox(
+            opts = {
+              label = "Checkbox #$fieldNumber"
+              indeterminate = indeterminateEnabled
+            },
+            attrs = {
+              checked(fieldContent)
+              onInput { fieldContent = it.value }
+            }
+          )
+        }
       }
     }
   }

--- a/sandbox/src/jsMain/kotlin/main.kt
+++ b/sandbox/src/jsMain/kotlin/main.kt
@@ -13,6 +13,7 @@ fun main() {
       MDCLayoutGridCells {
         Samples.forEach { it() }
       }
+      MultipleFieldsSample()
     }
   }
 }

--- a/sandbox/src/jsMain/kotlin/sample/TextField.s.kt
+++ b/sandbox/src/jsMain/kotlin/sample/TextField.s.kt
@@ -12,9 +12,9 @@ val TextFieldSamples = Samples {
   Sample {
     var text by remember { mutableStateOf("") }
     MDCTextField(
+      text,
       opts = { label = "Sample TextField" },
       attrs = {
-        value(text)
         onInput { text = it.value }
       }
     )


### PR DESCRIPTION
Fixes the behavior of value changes between empty and non-empty: Makes floating labels dance and notches open.

Previous behavior was:
> With several text fields sharing a common mutable state, the following happens: Changing from empty to non-empty works in the focused field. The notch opens, the label moves up. It does not work when non-focused fields receive their update: The notch remains closed, the floating label remains at the empty position, overwriting the updated text.

Included is a sample to check the behavior of multiple synchronized fields.