### PR TITLE
kmdc-icons: allow to use span or i tag for material icons

### DIFF
--- a/lib/kmdc-icons/src/jsMain/kotlin/MDCIcon.kt
+++ b/lib/kmdc-icons/src/jsMain/kotlin/MDCIcon.kt
@@ -80,7 +80,7 @@ public data class MDCIconOpts(
     ElevenMp("11mp"),
     TwelveMp("12mp"),
     ThirteenMp("13mp"),
-    FourtheenMp("14mp"),
+    FourteenMp("14mp"),
     FifteenMp("15mp"),
     SixteenMp("16mp"),
     SeventeenMp("17mp"),

--- a/lib/kmdc-icons/src/jsMain/kotlin/MDCIcon.kt
+++ b/lib/kmdc-icons/src/jsMain/kotlin/MDCIcon.kt
@@ -8,6 +8,7 @@ import org.jetbrains.compose.web.dom.I
 import org.jetbrains.compose.web.dom.Span
 import org.jetbrains.compose.web.dom.Text
 import org.w3c.dom.HTMLElement
+import org.w3c.dom.HTMLSpanElement
 
 @JsModule("material-icons/iconfont/material-icons.css")
 private external val MDCIconStyle: dynamic
@@ -16,7 +17,7 @@ private external val MDCIconStyle: dynamic
 @Composable
 public fun MDCIconSpan(
   opts: Builder<MDCIconOpts>? = null,
-  attrs: AttrBuilderContext<out HTMLElement>? = null)
+  attrs: AttrBuilderContext<HTMLSpanElement>? = null)
 {
   MDCIconStyle
   val options = MDCIconOpts().apply { opts?.invoke(this) }
@@ -33,7 +34,7 @@ public fun MDCIconSpan(
 @Composable
 public fun MDCIconI(
   opts: Builder<MDCIconOpts>? = null,
-  attrs: AttrBuilderContext<out HTMLElement>? = null)
+  attrs: AttrBuilderContext<HTMLElement>? = null)
 {
   MDCIconStyle
   val options = MDCIconOpts().apply { opts?.invoke(this) }

--- a/lib/kmdc-icons/src/jsMain/kotlin/MDCIcon.kt
+++ b/lib/kmdc-icons/src/jsMain/kotlin/MDCIcon.kt
@@ -7,36 +7,55 @@ import org.jetbrains.compose.web.dom.AttrBuilderContext
 import org.jetbrains.compose.web.dom.I
 import org.jetbrains.compose.web.dom.Span
 import org.jetbrains.compose.web.dom.Text
+import org.w3c.dom.HTMLElement
 
 @JsModule("material-icons/iconfont/material-icons.css")
 private external val MDCIconStyle: dynamic
+
+@MDCDsl
+@Composable
+public fun MDCIconSpan(
+  opts: Builder<MDCIconOpts>? = null,
+  attrs: AttrBuilderContext<out HTMLElement>? = null)
+{
+  MDCIconStyle
+  val options = MDCIconOpts().apply { opts?.invoke(this) }
+
+  Span(attrs = {
+    classes(*options.type.classes)
+    attrs?.invoke(this)
+  }) {
+    Text(options.icon.iconType)
+  }
+}
+
+@MDCDsl
+@Composable
+public fun MDCIconI(
+  opts: Builder<MDCIconOpts>? = null,
+  attrs: AttrBuilderContext<out HTMLElement>? = null)
+{
+  MDCIconStyle
+  val options = MDCIconOpts().apply { opts?.invoke(this) }
+
+  I(attrs = {
+    classes(*options.type.classes)
+    attrs?.invoke(this)
+  }) {
+    Text(options.icon.iconType)
+  }
+}
 
 /**
  * [JS API](https://github.com/marella/material-icons/tree/v1.10.4)
  */
 @MDCDsl
 @Composable
-public fun MDCIcon(opts: Builder<MDCIconOpts>? = null, attrs: AttrBuilderContext<*>? = null) {
-  MDCIconStyle
+public fun MDCIcon(opts: Builder<MDCIconOpts>? = null, attrs: AttrBuilderContext<out HTMLElement>? = null) {
   val options = MDCIconOpts().apply { opts?.invoke(this) }
-
   when (options.base) {
-    MDCIconOpts.MDCIconBase.Span -> {
-      Span(attrs = {
-        classes(*options.type.classes)
-        attrs?.invoke(this)
-      }) {
-        Text(options.icon.iconType)
-      }
-    }
-    MDCIconOpts.MDCIconBase.I -> {
-      I(attrs = {
-        classes(*options.type.classes)
-        attrs?.invoke(this)
-      }) {
-        Text(options.icon.iconType)
-      }
-    }
+    MDCIconOpts.MDCIconBase.Span -> MDCIconSpan(opts, attrs)
+    MDCIconOpts.MDCIconBase.I -> MDCIconI(opts, attrs)
   }
 }
 

--- a/lib/kmdc-icons/src/jsMain/kotlin/MDCIcon.kt
+++ b/lib/kmdc-icons/src/jsMain/kotlin/MDCIcon.kt
@@ -4,9 +4,9 @@ import androidx.compose.runtime.Composable
 import dev.petuska.kmdc.core.Builder
 import dev.petuska.kmdc.core.MDCDsl
 import org.jetbrains.compose.web.dom.AttrBuilderContext
+import org.jetbrains.compose.web.dom.I
 import org.jetbrains.compose.web.dom.Span
 import org.jetbrains.compose.web.dom.Text
-import org.w3c.dom.HTMLSpanElement
 
 @JsModule("material-icons/iconfont/material-icons.css")
 private external val MDCIconStyle: dynamic
@@ -16,21 +16,34 @@ private external val MDCIconStyle: dynamic
  */
 @MDCDsl
 @Composable
-public fun MDCIcon(opts: Builder<MDCIconOpts>? = null, attrs: AttrBuilderContext<HTMLSpanElement>? = null) {
+public fun MDCIcon(opts: Builder<MDCIconOpts>? = null, attrs: AttrBuilderContext<*>? = null) {
   MDCIconStyle
   val options = MDCIconOpts().apply { opts?.invoke(this) }
-  Span(attrs = {
-    classes(*options.type.classes)
-    attrs?.invoke(this)
-  }) {
-    Text(options.icon.iconType)
+
+  when (options.base) {
+    MDCIconOpts.MDCIconBase.Span -> {
+      Span(attrs = {
+        classes(*options.type.classes)
+        attrs?.invoke(this)
+      }) {
+        Text(options.icon.iconType)
+      }
+    }
+    MDCIconOpts.MDCIconBase.I -> {
+      I(attrs = {
+        classes(*options.type.classes)
+        attrs?.invoke(this)
+      }) {
+        Text(options.icon.iconType)
+      }
+    }
   }
 }
 
-
 public data class MDCIconOpts(
   var type: Type = Type.Filled,
-  var icon: MDCIconType = MDCIconType.None
+  var icon: MDCIconType = MDCIconType.None,
+  var base: MDCIconBase = MDCIconBase.Span
 ) {
   public enum class Type(public vararg val classes: String) {
     Filled("material-icons"),
@@ -39,6 +52,8 @@ public data class MDCIconOpts(
     Sharp("material-icons-sharp"),
     TwoTone("material-icons-two-tone")
   }
+
+  public enum class MDCIconBase{Span, I}
 
   public enum class MDCIconType(public val iconType: String) {
     None("None"),


### PR DESCRIPTION
* A new MDCIconBase type allows the user so use either
  a default SPAN tag or the valid I tag to display
  the selected material icon.