### PR TITLE
Add support for MDCMenuSurface closed, closing, and opened events.

### DIFF
--- a/kmdc/kmdc-menu-surface/src/jsMain/kotlin/MDCMenuSurface.kt
+++ b/kmdc/kmdc-menu-surface/src/jsMain/kotlin/MDCMenuSurface.kt
@@ -16,7 +16,7 @@ public data class MDCMenuSurfaceOpts(
   public var fixed: Boolean = false,
 )
 
-public class MDCMenuSurfaceAttrsScope private constructor() : AttrsBuilder<HTMLDivElement>()
+public open class MDCMenuSurfaceAttrsScope() : AttrsBuilder<HTMLDivElement>()
 
 /**
  * [JS API](https://github.com/material-components/material-components-web/tree/v13.0.0/packages/mdc-menu-surface)

--- a/kmdc/kmdc-menu-surface/src/jsMain/kotlin/MDCMenuSurface.kt
+++ b/kmdc/kmdc-menu-surface/src/jsMain/kotlin/MDCMenuSurface.kt
@@ -16,6 +16,8 @@ public data class MDCMenuSurfaceOpts(
   public var fixed: Boolean = false,
 )
 
+public class MDCMenuSurfaceAttrsScope private constructor() : AttrsBuilder<HTMLDivElement>()
+
 /**
  * [JS API](https://github.com/material-components/material-components-web/tree/v13.0.0/packages/mdc-menu-surface)
  */
@@ -23,7 +25,7 @@ public data class MDCMenuSurfaceOpts(
 @Composable
 public fun MDCMenuSurface(
   opts: Builder<MDCMenuSurfaceOpts>? = null,
-  attrs: Builder<AttrsBuilder<HTMLDivElement>>? = null,
+  attrs: Builder<MDCMenuSurfaceAttrsScope>? = null,
   content: ContentBuilder<HTMLDivElement>? = null,
 ) {
   MDCMenuSurfaceStyle
@@ -33,7 +35,7 @@ public fun MDCMenuSurface(
       classes("mdc-menu-surface")
       if (options.fixed) classes("mdc-menu-surface--fixed")
       initialiseMDC(MDCMenuSurfaceModule.MDCMenuSurface::attachTo)
-      attrs?.invoke(this)
+      attrs?.invoke(this.unsafeCast<MDCMenuSurfaceAttrsScope>())
     },
     content = content
   )

--- a/kmdc/kmdc-menu-surface/src/jsMain/kotlin/MDCMenuSurfaceModule.kt
+++ b/kmdc/kmdc-menu-surface/src/jsMain/kotlin/MDCMenuSurfaceModule.kt
@@ -47,7 +47,5 @@ public external object MDCMenuSurfaceModule {
     public val item: Element
   }
 
-  public class MDCMenuSurfaceClosingEvent : MDCEvent<MDCMenuSurfaceEventDetail>
-  public class MDCMenuSurfaceClosedEvent : MDCEvent<MDCMenuSurfaceEventDetail>
-  public class MDCMenuSurfaceOpenedEvent : MDCEvent<MDCMenuSurfaceEventDetail>
+  public class MDCMenuSurfaceEvent : MDCEvent<MDCMenuSurfaceEventDetail>
 }

--- a/kmdc/kmdc-menu-surface/src/jsMain/kotlin/MDCMenuSurfaceModule.kt
+++ b/kmdc/kmdc-menu-surface/src/jsMain/kotlin/MDCMenuSurfaceModule.kt
@@ -1,5 +1,6 @@
 package dev.petuska.kmdc.menu.surface
 import dev.petuska.kmdc.core.Destroyable
+import dev.petuska.kmdc.core.MDCEvent
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLElement
 
@@ -41,4 +42,12 @@ public external object MDCMenuSurfaceModule {
     public val CLOSING_EVENT: String
     public val OPENED_EVENT: String
   }
+
+  public class MDCMenuSurfaceEventDetail {
+    public val item: Element
+  }
+
+  public class MDCMenuSurfaceClosingEvent : MDCEvent<MDCMenuSurfaceEventDetail>
+  public class MDCMenuSurfaceClosedEvent : MDCEvent<MDCMenuSurfaceEventDetail>
+  public class MDCMenuSurfaceOpenedEvent : MDCEvent<MDCMenuSurfaceEventDetail>
 }

--- a/kmdc/kmdc-menu-surface/src/jsMain/kotlin/MDCMenuSurfaceModule.kt
+++ b/kmdc/kmdc-menu-surface/src/jsMain/kotlin/MDCMenuSurfaceModule.kt
@@ -1,5 +1,6 @@
 package dev.petuska.kmdc.menu.surface
 import dev.petuska.kmdc.core.Destroyable
+import dev.petuska.kmdc.core.MDCEvent
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLElement
 
@@ -33,5 +34,12 @@ public external object MDCMenuSurfaceModule {
     public val TOP_END: Byte
     public val BOTTOM_START: Byte
     public val BOTTOM_END: Byte
+  }
+
+  @Suppress("ClassName")
+  public object strings {
+    public val CLOSED_EVENT: String
+    public val CLOSING_EVENT: String
+    public val OPENED_EVENT: String
   }
 }

--- a/kmdc/kmdc-menu-surface/src/jsMain/kotlin/MDCMenuSurfaceModule.kt
+++ b/kmdc/kmdc-menu-surface/src/jsMain/kotlin/MDCMenuSurfaceModule.kt
@@ -1,6 +1,5 @@
 package dev.petuska.kmdc.menu.surface
 import dev.petuska.kmdc.core.Destroyable
-import dev.petuska.kmdc.core.MDCEvent
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLElement
 

--- a/kmdc/kmdc-menu-surface/src/jsMain/kotlin/events.kt
+++ b/kmdc/kmdc-menu-surface/src/jsMain/kotlin/events.kt
@@ -21,4 +21,3 @@ public fun MDCMenuSurfaceAttrsScope.onClosing(listener: (event: SyntheticEvent<E
 public fun MDCMenuSurfaceAttrsScope.onOpened(listener: (event: SyntheticEvent<EventTarget>) -> Unit) {
   addEventListener(MDCMenuSurfaceModule.strings.OPENED_EVENT, listener)
 }
-

--- a/kmdc/kmdc-menu-surface/src/jsMain/kotlin/events.kt
+++ b/kmdc/kmdc-menu-surface/src/jsMain/kotlin/events.kt
@@ -6,22 +6,22 @@ import dev.petuska.kmdc.core.MDCAttrsDsl
  * [JS API](https://github.com/material-components/material-components-web/tree/v13.0.0/packages/mdc-menu-surface)
  */
 @MDCAttrsDsl
-public fun MDCMenuSurfaceAttrsScope.onClosed(listener: (event: MDCMenuSurfaceModule.MDCMenuSurfaceClosedEvent) -> Unit) {
+public fun MDCMenuSurfaceAttrsScope.onClosed(listener: (event: MDCMenuSurfaceModule.MDCMenuSurfaceEvent) -> Unit) {
   addEventListener(MDCMenuSurfaceModule.strings.CLOSED_EVENT) {
-    listener(it.nativeEvent.unsafeCast<MDCMenuSurfaceModule.MDCMenuSurfaceClosedEvent>())
+    listener(it.nativeEvent.unsafeCast<MDCMenuSurfaceModule.MDCMenuSurfaceEvent>())
   }
 }
 
 @MDCAttrsDsl
-public fun MDCMenuSurfaceAttrsScope.onClosing(listener: (event: MDCMenuSurfaceModule.MDCMenuSurfaceClosingEvent) -> Unit) {
+public fun MDCMenuSurfaceAttrsScope.onClosing(listener: (event: MDCMenuSurfaceModule.MDCMenuSurfaceEvent) -> Unit) {
   addEventListener(MDCMenuSurfaceModule.strings.CLOSING_EVENT) {
-    listener(it.nativeEvent.unsafeCast<MDCMenuSurfaceModule.MDCMenuSurfaceClosingEvent>())
+    listener(it.nativeEvent.unsafeCast<MDCMenuSurfaceModule.MDCMenuSurfaceEvent>())
   }
 }
 
 @MDCAttrsDsl
-public fun MDCMenuSurfaceAttrsScope.onOpened(listener: (event: MDCMenuSurfaceModule.MDCMenuSurfaceOpenedEvent) -> Unit) {
+public fun MDCMenuSurfaceAttrsScope.onOpened(listener: (event: MDCMenuSurfaceModule.MDCMenuSurfaceEvent) -> Unit) {
   addEventListener(MDCMenuSurfaceModule.strings.OPENED_EVENT) {
-    listener(it.nativeEvent.unsafeCast<MDCMenuSurfaceModule.MDCMenuSurfaceOpenedEvent>())
+    listener(it.nativeEvent.unsafeCast<MDCMenuSurfaceModule.MDCMenuSurfaceEvent>())
   }
 }

--- a/kmdc/kmdc-menu-surface/src/jsMain/kotlin/events.kt
+++ b/kmdc/kmdc-menu-surface/src/jsMain/kotlin/events.kt
@@ -1,23 +1,27 @@
 package dev.petuska.kmdc.menu.surface
 
-import androidx.compose.web.events.SyntheticEvent
 import dev.petuska.kmdc.core.MDCAttrsDsl
-import org.w3c.dom.events.EventTarget
 
 /**
  * [JS API](https://github.com/material-components/material-components-web/tree/v13.0.0/packages/mdc-menu-surface)
  */
 @MDCAttrsDsl
-public fun MDCMenuSurfaceAttrsScope.onClosed(listener: (event: SyntheticEvent<EventTarget>) -> Unit) {
-  addEventListener(MDCMenuSurfaceModule.strings.CLOSED_EVENT, listener)
+public fun MDCMenuSurfaceAttrsScope.onClosed(listener: (event: MDCMenuSurfaceModule.MDCMenuSurfaceClosedEvent) -> Unit) {
+  addEventListener(MDCMenuSurfaceModule.strings.CLOSED_EVENT) {
+    listener(it.nativeEvent.unsafeCast<MDCMenuSurfaceModule.MDCMenuSurfaceClosedEvent>())
+  }
 }
 
 @MDCAttrsDsl
-public fun MDCMenuSurfaceAttrsScope.onClosing(listener: (event: SyntheticEvent<EventTarget>) -> Unit) {
-  addEventListener(MDCMenuSurfaceModule.strings.CLOSING_EVENT, listener)
+public fun MDCMenuSurfaceAttrsScope.onClosing(listener: (event: MDCMenuSurfaceModule.MDCMenuSurfaceClosingEvent) -> Unit) {
+  addEventListener(MDCMenuSurfaceModule.strings.CLOSING_EVENT) {
+    listener(it.nativeEvent.unsafeCast<MDCMenuSurfaceModule.MDCMenuSurfaceClosingEvent>())
+  }
 }
 
 @MDCAttrsDsl
-public fun MDCMenuSurfaceAttrsScope.onOpened(listener: (event: SyntheticEvent<EventTarget>) -> Unit) {
-  addEventListener(MDCMenuSurfaceModule.strings.OPENED_EVENT, listener)
+public fun MDCMenuSurfaceAttrsScope.onOpened(listener: (event: MDCMenuSurfaceModule.MDCMenuSurfaceOpenedEvent) -> Unit) {
+  addEventListener(MDCMenuSurfaceModule.strings.OPENED_EVENT) {
+    listener(it.nativeEvent.unsafeCast<MDCMenuSurfaceModule.MDCMenuSurfaceOpenedEvent>())
+  }
 }

--- a/kmdc/kmdc-menu-surface/src/jsMain/kotlin/events.kt
+++ b/kmdc/kmdc-menu-surface/src/jsMain/kotlin/events.kt
@@ -1,0 +1,24 @@
+package dev.petuska.kmdc.menu.surface
+
+import androidx.compose.web.events.SyntheticEvent
+import dev.petuska.kmdc.core.MDCAttrsDsl
+import org.w3c.dom.events.EventTarget
+
+/**
+ * [JS API](https://github.com/material-components/material-components-web/tree/v13.0.0/packages/mdc-menu-surface)
+ */
+@MDCAttrsDsl
+public fun MDCMenuSurfaceAttrsScope.onClosed(listener: (event: SyntheticEvent<EventTarget>) -> Unit) {
+  addEventListener(MDCMenuSurfaceModule.strings.CLOSED_EVENT, listener)
+}
+
+@MDCAttrsDsl
+public fun MDCMenuSurfaceAttrsScope.onClosing(listener: (event: SyntheticEvent<EventTarget>) -> Unit) {
+  addEventListener(MDCMenuSurfaceModule.strings.CLOSING_EVENT, listener)
+}
+
+@MDCAttrsDsl
+public fun MDCMenuSurfaceAttrsScope.onOpened(listener: (event: SyntheticEvent<EventTarget>) -> Unit) {
+  addEventListener(MDCMenuSurfaceModule.strings.OPENED_EVENT, listener)
+}
+

--- a/kmdc/kmdc-menu/src/jsMain/kotlin/MDCMenu.kt
+++ b/kmdc/kmdc-menu/src/jsMain/kotlin/MDCMenu.kt
@@ -1,13 +1,17 @@
 package dev.petuska.kmdc.menu
 
 import androidx.compose.runtime.Composable
-import dev.petuska.kmdc.core.*
+import dev.petuska.kmdc.core.Builder
+import dev.petuska.kmdc.core.ComposableBuilder
+import dev.petuska.kmdc.core.MDCDsl
+import dev.petuska.kmdc.core.initialiseMDC
+import dev.petuska.kmdc.core.mdc
+import dev.petuska.kmdc.core.role
 import dev.petuska.kmdc.list.MDCList
 import dev.petuska.kmdc.list.MDCListScope
 import dev.petuska.kmdc.menu.surface.MDCMenuSurface
-import org.jetbrains.compose.web.attributes.AttrsBuilder
+import dev.petuska.kmdc.menu.surface.MDCMenuSurfaceAttrsScope
 import org.jetbrains.compose.web.dom.ElementScope
-import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLUListElement
 
 @JsModule("@material/menu/dist/mdc.menu.css")
@@ -24,7 +28,7 @@ public data class MDCMenuOpts(
   public data class Point(var x: Double = 0.0, var y: Double = 0.0)
 }
 
-public class MDCMenuAttrsScope private constructor() : AttrsBuilder<HTMLDivElement>()
+public class MDCMenuAttrsScope private constructor() : MDCMenuSurfaceAttrsScope()
 
 public class MDCMenuScope(scope: ElementScope<HTMLUListElement>) : MDCListScope<HTMLUListElement>(scope)
 

--- a/kmdc/kmdc-menu/src/jsMain/kotlin/events.kt
+++ b/kmdc/kmdc-menu/src/jsMain/kotlin/events.kt
@@ -1,6 +1,9 @@
+import androidx.compose.web.events.SyntheticEvent
 import dev.petuska.kmdc.core.MDCAttrsDsl
 import dev.petuska.kmdc.menu.MDCMenuAttrsScope
 import dev.petuska.kmdc.menu.MDCMenuModule
+import dev.petuska.kmdc.menu.surface.MDCMenuSurfaceModule
+import org.w3c.dom.events.EventTarget
 
 /**
  * [JS API](https://github.com/material-components/material-components-web/tree/v13.0.0/packages/mdc-menu)
@@ -10,4 +13,22 @@ public fun MDCMenuAttrsScope.onSelected(listener: (event: MDCMenuModule.MDCMenuS
   addEventListener(MDCMenuModule.strings.SELECTED_EVENT) {
     listener(it.nativeEvent.unsafeCast<MDCMenuModule.MDCMenuSelectedEvent>())
   }
+}
+
+/**
+ * [JS API](https://github.com/material-components/material-components-web/tree/v13.0.0/packages/mdc-menu-surface)
+ */
+@MDCAttrsDsl
+public fun MDCMenuAttrsScope.onClosed(listener: (event: SyntheticEvent<EventTarget>) -> Unit) {
+  addEventListener(MDCMenuSurfaceModule.strings.CLOSED_EVENT, listener)
+}
+
+@MDCAttrsDsl
+public fun MDCMenuAttrsScope.onClosing(listener: (event: SyntheticEvent<EventTarget>) -> Unit) {
+  addEventListener(MDCMenuSurfaceModule.strings.CLOSING_EVENT, listener)
+}
+
+@MDCAttrsDsl
+public fun MDCMenuAttrsScope.onOpened(listener: (event: SyntheticEvent<EventTarget>) -> Unit) {
+  addEventListener(MDCMenuSurfaceModule.strings.OPENED_EVENT, listener)
 }

--- a/kmdc/kmdc-menu/src/jsMain/kotlin/events.kt
+++ b/kmdc/kmdc-menu/src/jsMain/kotlin/events.kt
@@ -1,9 +1,6 @@
-import androidx.compose.web.events.SyntheticEvent
 import dev.petuska.kmdc.core.MDCAttrsDsl
 import dev.petuska.kmdc.menu.MDCMenuAttrsScope
 import dev.petuska.kmdc.menu.MDCMenuModule
-import dev.petuska.kmdc.menu.surface.MDCMenuSurfaceModule
-import org.w3c.dom.events.EventTarget
 
 /**
  * [JS API](https://github.com/material-components/material-components-web/tree/v13.0.0/packages/mdc-menu)
@@ -13,22 +10,4 @@ public fun MDCMenuAttrsScope.onSelected(listener: (event: MDCMenuModule.MDCMenuS
   addEventListener(MDCMenuModule.strings.SELECTED_EVENT) {
     listener(it.nativeEvent.unsafeCast<MDCMenuModule.MDCMenuSelectedEvent>())
   }
-}
-
-/**
- * [JS API](https://github.com/material-components/material-components-web/tree/v13.0.0/packages/mdc-menu-surface)
- */
-@MDCAttrsDsl
-public fun MDCMenuAttrsScope.onClosed(listener: (event: SyntheticEvent<EventTarget>) -> Unit) {
-  addEventListener(MDCMenuSurfaceModule.strings.CLOSED_EVENT, listener)
-}
-
-@MDCAttrsDsl
-public fun MDCMenuAttrsScope.onClosing(listener: (event: SyntheticEvent<EventTarget>) -> Unit) {
-  addEventListener(MDCMenuSurfaceModule.strings.CLOSING_EVENT, listener)
-}
-
-@MDCAttrsDsl
-public fun MDCMenuAttrsScope.onOpened(listener: (event: SyntheticEvent<EventTarget>) -> Unit) {
-  addEventListener(MDCMenuSurfaceModule.strings.OPENED_EVENT, listener)
 }

--- a/sandbox/src/jsMain/kotlin/samples/Menu.s.kt
+++ b/sandbox/src/jsMain/kotlin/samples/Menu.s.kt
@@ -7,12 +7,12 @@ import dev.petuska.kmdc.menu.MDCMenuItem
 import dev.petuska.kmdc.menu.MDCMenuOpts
 import dev.petuska.kmdc.menu.surface.MDCMenuSurfaceAnchor
 import dev.petuska.kmdc.menu.surface.MDCMenuSurfaceModule
+import dev.petuska.kmdc.menu.surface.onClosed
 import dev.petuska.kmdc.textfield.MDCTextField
 import dev.petuska.kmdc.textfield.MDCTextFieldCommonOpts
 import local.sandbox.engine.Sample
 import local.sandbox.engine.Samples
 import onSelected
-import onClosed
 import org.jetbrains.compose.web.dom.Text
 
 private val SAMPLE_MENU = listOf("Menu Item 1", "Menu Item 2", "Menu Item 3")
@@ -38,7 +38,6 @@ private fun MenuPositioned() {
     open = menuOpen
     absolutePosition = MDCMenuOpts.Point(100.0, 200.0)
   }, attrs = {
-    onSelected { menuOpen = false }
     onClosed { menuOpen = false }
   }) {
     SAMPLE_MENU.map {

--- a/sandbox/src/jsMain/kotlin/samples/Menu.s.kt
+++ b/sandbox/src/jsMain/kotlin/samples/Menu.s.kt
@@ -12,6 +12,7 @@ import dev.petuska.kmdc.textfield.MDCTextFieldCommonOpts
 import local.sandbox.engine.Sample
 import local.sandbox.engine.Samples
 import onSelected
+import onClosed
 import org.jetbrains.compose.web.dom.Text
 
 private val SAMPLE_MENU = listOf("Menu Item 1", "Menu Item 2", "Menu Item 3")
@@ -38,6 +39,7 @@ private fun MenuPositioned() {
     absolutePosition = MDCMenuOpts.Point(100.0, 200.0)
   }, attrs = {
     onSelected { menuOpen = false }
+    onClosed { menuOpen = false }
   }) {
     SAMPLE_MENU.map {
       MDCMenuItem { Text(it) }
@@ -68,6 +70,7 @@ private fun MenuAnchored() {
         selectedValue = SAMPLE_MENU[it.detail.index]
         menuOpen = false
       }
+      onClosed { menuOpen = false }
     }
     ) {
       SAMPLE_MENU.map {


### PR DESCRIPTION
Addresses #70 by adding support for the closed event. The event is fundamentally for the MDCMenuSurface class, but since the Composable MDCMenu uses MDCMenuSurface internally, therefore hiding it from callers, the events were also exposed in MDCMenuAttrsScope.