### PR TITLE
Apply mdc-line-ripple only for Filled select type.

### DIFF
--- a/kmdc/kmdc-select/src/jsMain/kotlin/MDCSelectAnchor.kt
+++ b/kmdc/kmdc-select/src/jsMain/kotlin/MDCSelectAnchor.kt
@@ -57,7 +57,9 @@ internal fun <T> MDCSelectAnchor(
 
     MDCSelectDownArrowIcon()
 
-    Span(attrs = { classes("mdc-line-ripple") })
+    if (options.type == MDCSelectOpts.Type.Filled) {
+      Span(attrs = { classes("mdc-line-ripple") })
+    }
   }
 }
 


### PR DESCRIPTION
A visual underline artifact was present when using the outlined select type due to `<span class="mdc-line-ripple"></span>` being applied. Per the [documentation](https://github.com/material-components/material-components-web/tree/master/packages/mdc-select), this span is not used for the Outlined type.