### PR TITLE
Recreate MDCSelect when changing the items list to fix behavior.

### DIFF
--- a/kmdc/kmdc-select/src/jsMain/kotlin/MDCSelect.kt
+++ b/kmdc/kmdc-select/src/jsMain/kotlin/MDCSelect.kt
@@ -6,7 +6,6 @@ import dev.petuska.kmdc.core.Builder
 import dev.petuska.kmdc.core.MDCDsl
 import dev.petuska.kmdc.core.MDCSideEffect
 import dev.petuska.kmdc.core.aria
-import dev.petuska.kmdc.core.initialiseMDC
 import dev.petuska.kmdc.core.mdc
 import dev.petuska.kmdc.core.rememberUniqueDomElementId
 import dev.petuska.kmdc.core.role
@@ -91,26 +90,22 @@ public fun <T> MDCSelect(
           aria("describedby", helperTextId)
         }
       }
-      initialiseMDC<HTMLDivElement, MDCSelectModule.MDCSelect<T>>(MDCSelectModule.MDCSelect.Companion::attachTo) {
-        this.items = items
-      }
       attrs?.invoke(MDCSelectAttrsScope(this))
     }
   ) {
-    MDCSideEffect(options.required, MDCSelectModule.MDCSelect<T>::required)
-    MDCSideEffect(options.disabled, MDCSelectModule.MDCSelect<T>::disabled)
     DisposableEffect(items) {
-      scopeElement.mdc<MDCSelectModule.MDCSelect<T>> {
-        destroy()
-      }
       scopeElement.asDynamic().mdc = MDCSelectModule.MDCSelect.attachTo<T>(scopeElement)
       scopeElement.mdc<MDCSelectModule.MDCSelect<T>> {
         this.items = items
         required = options.required
         disabled = options.disabled
       }
-      onDispose { }
+      onDispose {
+        scopeElement.mdc<MDCSelectModule.MDCSelect<T>> { destroy() }
+      }
     }
+    MDCSideEffect(options.required, MDCSelectModule.MDCSelect<T>::required)
+    MDCSideEffect(options.disabled, MDCSelectModule.MDCSelect<T>::disabled)
     MDCSideEffect<MDCSelectModule.MDCSelect<T>>(options.value) {
       value = options.value?.itemValue()
     }

--- a/kmdc/kmdc-select/src/jsMain/kotlin/MDCSelect.kt
+++ b/kmdc/kmdc-select/src/jsMain/kotlin/MDCSelect.kt
@@ -1,11 +1,13 @@
 package dev.petuska.kmdc.select
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import dev.petuska.kmdc.core.Builder
 import dev.petuska.kmdc.core.MDCDsl
 import dev.petuska.kmdc.core.MDCSideEffect
 import dev.petuska.kmdc.core.aria
 import dev.petuska.kmdc.core.initialiseMDC
+import dev.petuska.kmdc.core.mdc
 import dev.petuska.kmdc.core.rememberUniqueDomElementId
 import dev.petuska.kmdc.core.role
 import dev.petuska.kmdc.list.MDCList
@@ -97,6 +99,18 @@ public fun <T> MDCSelect(
   ) {
     MDCSideEffect(options.required, MDCSelectModule.MDCSelect<T>::required)
     MDCSideEffect(options.disabled, MDCSelectModule.MDCSelect<T>::disabled)
+    DisposableEffect(items) {
+      scopeElement.mdc<MDCSelectModule.MDCSelect<T>> {
+        destroy()
+      }
+      scopeElement.asDynamic().mdc = MDCSelectModule.MDCSelect.attachTo<T>(scopeElement)
+      scopeElement.mdc<MDCSelectModule.MDCSelect<T>> {
+        this.items = items
+        required = options.required
+        disabled = options.disabled
+      }
+      onDispose { }
+    }
     MDCSideEffect<MDCSelectModule.MDCSelect<T>>(options.value) {
       value = options.value?.itemValue()
     }

--- a/kmdc/kmdc-select/src/jsMain/kotlin/events.kt
+++ b/kmdc/kmdc-select/src/jsMain/kotlin/events.kt
@@ -14,7 +14,7 @@ public fun <T> MDCSelectAttrsScope<T>.onChange(listener: (value: T) -> Unit) {
     (event.currentTarget as? Element)
       ?.mdc<MDCSelectModule.MDCSelect<T>> {
         if (event.detail.index == -1) {
-          console.warn("MDCSelect component - index -1 for change event")
+          console.warn("MDCSelect component - set value's index not found for change event")
         } else {
           listener(items[event.detail.index])
         }

--- a/kmdc/kmdc-select/src/jsMain/kotlin/events.kt
+++ b/kmdc/kmdc-select/src/jsMain/kotlin/events.kt
@@ -13,7 +13,11 @@ public fun <T> MDCSelectAttrsScope<T>.onChange(listener: (value: T) -> Unit) {
     val event = it.nativeEvent.unsafeCast<MDCSelectModule.MDCSelectChangeEvent>()
     (event.currentTarget as? Element)
       ?.mdc<MDCSelectModule.MDCSelect<T>> {
-        listener(items[event.detail.index])
+        if (event.detail.index == -1) {
+          console.warn("MDCSelect component - index -1 for change event")
+        } else {
+          listener(items[event.detail.index])
+        }
       }
       ?: console.warn("MDCSelect component - current target not found for change event")
   }

--- a/sandbox/src/jsMain/kotlin/samples/Select.kt
+++ b/sandbox/src/jsMain/kotlin/samples/Select.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import dev.petuska.kmdc.checkbox.MDCCheckbox
 import dev.petuska.kmdc.form.field.MDCFormField
+import dev.petuska.kmdc.radio.MDCRadio
 import dev.petuska.kmdc.select.MDCSelect
 import dev.petuska.kmdc.select.MDCSelectOpts
 import dev.petuska.kmdc.select.onChange
@@ -134,6 +135,57 @@ private val SelectSamples = Samples("MDCSelect") {
       }
     )
   }
+
+  Sample("With changing list") {
+    var fruitList by remember { mutableStateOf(true) }
+    var selectedFruit by remember { mutableStateOf(fruits[0]) }
+    var selectedVegetable by remember { mutableStateOf(vegetables[0]) }
+
+    Div {
+      MDCFormField {
+        MDCRadio(
+          checked = fruitList,
+          opts = { label = "Fruits" },
+          attrs = {
+            onInput { fruitList = true }
+          }
+        )
+        MDCRadio(
+          checked = !fruitList,
+          opts = { label = "Vegetables" },
+          attrs = {
+            onInput { fruitList = false }
+          }
+        )
+      }
+    }
+
+    MDCSelect(
+      if (fruitList) {
+        fruits
+      } else {
+        vegetables
+      },
+      opts = {
+        value = if (fruitList) {
+          selectedFruit
+        } else {
+          selectedVegetable
+        }
+      },
+      attrs = {
+        onChange {
+          if (fruitList) {
+            selectedFruit = it
+          } else {
+            selectedVegetable = it
+          }
+        }
+      }
+    )
+  }
 }
 
 private val fruits = listOf("", "Apple", "Orange", "Banana")
+
+private val vegetables = listOf("", "Lettuce", "Celery")


### PR DESCRIPTION
After component creation, if the items list was changed and contained different values and/or a different length from the list used at creation, a change event with an incorrect index (e.g. -1) would be fired causing an exception and errant behavior. 

During initialization, the material-components-web MDCSelect class builds a list of items based on elements with the data-value attribute. When the items change, this list isn't recreated. The fix in this PR destroys the existing MDCSelect object and creates a new instance whenever the items change, causing the new MDCSelect object to be initialized based on the element tree created from the new items list.